### PR TITLE
Changed name to members-for-kofi to not misuse the kofi brand.

### DIFF
--- a/.releaseignore
+++ b/.releaseignore
@@ -10,3 +10,4 @@ package-lock.json
 *.log
 *.tmp
 README.md
+release

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-WORKDIR /var/www/html/wp-content/plugins/kofi-members
+WORKDIR /var/www/html/wp-content/plugins/members-for-kofi
 COPY . .
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer

--- a/LICENSE
+++ b/LICENSE
@@ -1,52 +1,674 @@
-                GNU GENERAL PUBLIC LICENSE
-                   Version 3, 29 June 2007
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. https://fsf.org/
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-                        Preamble
+                            Preamble
 
-The GNU General Public License is a free, copyleft license for
+  The GNU General Public License is a free, copyleft license for
 software and other kinds of works.
 
-The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works. By contrast,
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
 the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program–to make sure it remains free
-software for all its users. We, the Free Software Foundation, use the
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
 GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors. You can apply it to
+any other work released this way by its authors.  You can apply it to
 your programs, too.
 
-When we speak of free software, we are referring to freedom, not
-price. Our General Public Licenses are designed to make sure that you
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights. Therefore, you have
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
 certain responsibilities if you distribute copies of the software, or if
 you modify it: responsibilities to respect the freedom of others.
 
-For example, if you distribute copies of such a program, whether
+  For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received. You must make sure that they, too, receive
-or can get the source code. And you must show them these terms so they
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
 know their rights.
 
-Developers that use the GNU GPL protect your rights with two steps:
+  Developers that use the GNU GPL protect your rights with two steps:
 (1) assert copyright on the software, and (2) offer you this License
 giving you legal permission to copy, distribute and/or modify it.
 
-For the developers’ and authors’ protection, the GPL clearly explains
-that there is no warranty for this free software. For both users’ and
-authors’ sake, the GPL requires that modified versions be marked as
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
 changed, so that their problems will not be attributed erroneously to
 authors of previous versions.
 
-Some devices are designed to deny users access to install or run
+  Some devices are designed to deny users access to install or run
 modified versions of the software inside them, although the manufacturer
-can do so. This
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,6 @@ release: .releaseignore
 	rm -rf release
 	mkdir release
 	rsync -av --exclude-from='.releaseignore' ./ release/
-	cd release && zip -r ../kofi-members-$(VERSION).zip .
+	cd release && zip -r ../members-for-kofi.zip .
 	rm -rf release
-	@echo "Release created: kofi-members-$(VERSION).zip"
+	@echo "Release created: members-for-kofi.zip"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Listens for Ko-fi webhook events.
 - Automatically creates new users or updates existing ones.
-- Assigns WordPress roles based on Members for Ko-fihip tiers.
+- Assigns WordPress roles based on Ko-fi membership tiers.
 - Supports default roles for unmapped tiers.
 - Optional expiration of assigned roles.
 - Daily cron job to clean up expired roles.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Ko-fi Members for WordPress
+# Members for Ko-fi for WordPress
 
-**Ko-fi Members** is a WordPress plugin that integrates with [Ko-fi](https://ko-fi.com) to manage members based on donation tiers. It automatically creates users, assigns roles, and manages expiration of those roles based on webhook payloads received from Ko-fi.
+**Members for Ko-fi** is a WordPress plugin that integrates with [Ko-fi](https://ko-fi.com) to manage members based on donation tiers. It automatically creates users, assigns roles, and manages expiration of those roles based on webhook payloads received from Ko-fi.
 
 ## Features
 
 - Listens for Ko-fi webhook events.
 - Automatically creates new users or updates existing ones.
-- Assigns WordPress roles based on Ko-fi membership tiers.
+- Assigns WordPress roles based on Members for Ko-fihip tiers.
 - Supports default roles for unmapped tiers.
 - Optional expiration of assigned roles.
 - Daily cron job to clean up expired roles.
@@ -16,11 +16,11 @@
 ## Installation
 
 1. Clone the repository or download it as a ZIP file.
-2. Upload the plugin to your WordPress installation under `wp-content/plugins/kofi-members`.
+2. Upload the plugin to your WordPress installation under `wp-content/plugins/members-for-kofi`.
 3. Activate the plugin in the WordPress admin panel.
-4. Configure your settings via the Ko-fi Members admin page.
+4. Configure your settings via the Members for Ko-fi admin page.
 5. Go to `https://ko-fi.com/manage/webhooks?src=sidemenu`.
-6. Set your Ko-fi webhook to `https://your-site.com/kofi-webhook`.
+6. Set your Ko-fi webhook to `https://your-site.com/webhook-kofi`.
 6. Copy the Verification Token (under Advanced) to the settings.
 
 ## Configuration
@@ -34,7 +34,7 @@
 
 ## Logging
 
-Log messages are written to `wp-content/logs/kofi-members.log`. 
+Log messages are written to `wp-content/logs/members-for-kofi.log`. 
 
 ## Development
 
@@ -50,7 +50,7 @@ make test
 
 ## License
 
-This plugin is licensed under the [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.html). You are free to use, modify, and distribute it under the terms of that license.
+This plugin is licensed under the [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html). You are free to use, modify, and distribute it under the terms of that license.
 
 ## Contributing
 

--- a/assets/js/admin-settings.js
+++ b/assets/js/admin-settings.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
     const tabs = document.querySelectorAll('.nav-tab');
-    const tabContents = document.querySelectorAll('.kofi-members-tab');
+    const tabContents = document.querySelectorAll('.members-for-kofi-tab');
     const activeTabInput = document.getElementById('active_tab');
     const saveButton = document.querySelector('input[type="submit"]'); // Select the Save Settings button
 
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             // Show the corresponding tab content
             const activeTabId = this.getAttribute('href').split('tab=')[1];
-            document.getElementById(`kofi-members-tab-${activeTabId}`).style.display = '';
+            document.getElementById(`members-for-kofi-tab-${activeTabId}`).style.display = '';
 
             // Update the hidden input field with the active tab
             if (activeTabInput) {
@@ -142,7 +142,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     const copyButton = document.getElementById('copy-webhook-url');
-    const webhookInput = document.getElementById('kofi-webhook-url');
+    const webhookInput = document.getElementById('webhook-kofi-url');
 
     if (copyButton && webhookInput) {
         copyButton.addEventListener('click', function () {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     },
 	"autoload": {
 		"psr-4": {
-			"KofiMembers\\": "src/"
+			"MembersForKofi\\": "src/"
 		}
 	},
     "require-dev": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     depends_on:
       - db
     volumes:
-      - .:/var/www/html/wp-content/plugins/kofi-members
-    entrypoint: /var/www/html/wp-content/plugins/kofi-members/tests/setup-tests.sh
+      - .:/var/www/html/wp-content/plugins/members-for-kofi
+    entrypoint: /var/www/html/wp-content/plugins/members-for-kofi/tests/setup-tests.sh
     networks:
       - testnet
 

--- a/languages/members-for-kofi.pot
+++ b/languages/members-for-kofi.pot
@@ -2,8 +2,8 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Ko-fi Members 1.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/kofi-members\n"
+"Project-Id-Version: Members for Ko-fi 1.0.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/members-for-kofi\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -12,16 +12,16 @@ msgstr ""
 "POT-Creation-Date: 2025-07-30T05:15:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.6.0\n"
-"X-Domain: kofi-members\n"
+"X-Domain: members-for-kofi\n"
 
 #. Plugin Name of the plugin
 #: src/Plugin.php:135
 #: src/Plugin.php:136
-msgid "Ko-fi Members"
+msgid "Members for Ko-fi"
 msgstr ""
 
 #. Plugin URI of the plugin
-msgid "https://github.com/trudslev/kofi-members"
+msgid "https://github.com/trudslev/members-for-kofi"
 msgstr ""
 
 #. Description of the plugin
@@ -157,7 +157,7 @@ msgid "Minimum severity of log messages to record."
 msgstr ""
 
 #: src/Admin/AdminSettings.php:427
-msgid "Ko-fi Members Settings"
+msgid "Members for Ko-fi Settings"
 msgstr ""
 
 #: src/Admin/AdminSettings.php:430

--- a/members-for-kofi.php
+++ b/members-for-kofi.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,40 +15,38 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Plugin Name:       Ko-fi Members
- * Plugin URI:        https://github.com/trudslev/kofi-members
+ * Plugin Name:       Members for Ko-fi
+ * Plugin URI:        https://github.com/trudslev/members-for-kofi
  * Description:       Integrate with Ko-fi to manage WordPress users or roles via webhook.
  * Version:           1.0.0
  * Author:            Sune Adelowo Trudslev
  * Author URI:        https://foodgeek.io
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       kofi-members
+ * Text Domain:       members-for-kofi
  * Domain Path:       /languages
  */
 
 // Define plugin constants.
-define( 'KOFIMEMBERS_PLUGIN_FILE', __FILE__ );
-define( 'KOFIMEMBERS_PLUGIN_DIR', __DIR__ );
-define( 'KOFIMEMBERS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'MEMBERS_FOR_KOFI_PLUGIN_FILE', __FILE__ );
+define( 'MEMBERS_FOR_KOFI_PLUGIN_DIR', __DIR__ );
+define( 'MEMBERS_FOR_KOFI_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 // Load Composer autoloader.
-require_once KOFIMEMBERS_PLUGIN_DIR . '/vendor/autoload.php';
+require_once MEMBERS_FOR_KOFI_PLUGIN_DIR . '/vendor/autoload.php';
 
-use KofiMembers\Core\Activator;
-use KofiMembers\Core\Deactivator;
-use KofiMembers\Plugin;
+use MembersForKofi\Plugin;
 
 // Register activation and deactivation hooks.
-register_activation_hook( KOFIMEMBERS_PLUGIN_FILE, array( Plugin::class, 'activate' ) );
-register_deactivation_hook( KOFIMEMBERS_PLUGIN_FILE, array( Plugin::class, 'deactivate' ) );
-register_uninstall_hook( KOFIMEMBERS_PLUGIN_FILE, array( Plugin::class, 'uninstall' ) );
+register_activation_hook( MEMBERS_FOR_KOFI_PLUGIN_FILE, array( Plugin::class, 'activate' ) );
+register_deactivation_hook( MEMBERS_FOR_KOFI_PLUGIN_FILE, array( Plugin::class, 'deactivate' ) );
+register_uninstall_hook( MEMBERS_FOR_KOFI_PLUGIN_FILE, array( Plugin::class, 'uninstall' ) );
 
 // Boot the plugin after all plugins are loaded.
 add_action(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "kofi-members",
+  "name": "members-for-kofi",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,6 @@
     </coverage>
 
     <php>
-        <env name="WP_TESTS_PHPUNIT_POLYFILLS_PATH" value="/var/www/html/wp-content/plugins/kofi-members/vendor/yoast/phpunit-polyfills"/>
+        <env name="WP_TESTS_PHPUNIT_POLYFILLS_PATH" value="/var/www/html/wp-content/plugins/members-for-kofi/vendor/yoast/phpunit-polyfills"/>
     </php>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Ko-fi Members ===
+=== Members for Ko-fi ===
 Contributors: trudslev
 Donate link: https://ko-fi.com/
 Tags: ko-fi, membership, roles, webhook, user management
@@ -13,7 +13,7 @@ Integrate with Ko-fi to manage WordPress users or roles via webhook.
 
 == Description ==
 
-Ko-fi Members is a WordPress plugin that integrates with Ko-fi to manage WordPress users and roles based on Ko-fi webhooks. This plugin allows you to automate user role assignments, log donations, and manage memberships seamlessly.
+Members for Ko-fi is a WordPress plugin that integrates with Ko-fi to manage WordPress users and roles based on Ko-fi webhooks. This plugin allows you to automate user role assignments, log donations, and manage memberships seamlessly.
 
 **Features:**
 - Automatically assign roles to users based on Ko-fi donations or memberships.
@@ -28,9 +28,9 @@ Ko-fi Members is a WordPress plugin that integrates with Ko-fi to manage WordPre
 
 == Installation ==
 
-1. Upload the plugin files to the `/wp-content/plugins/kofi-members` directory, or install the plugin through the WordPress plugins screen directly.
+1. Upload the plugin files to the `/wp-content/plugins/members-for-kofi` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Configure the plugin settings under **Settings > Ko-fi Members**.
+3. Configure the plugin settings under **Settings > Members for Ko-fi**.
 4. Set up your Ko-fi webhook to point to your WordPress site.
 
 == Frequently Asked Questions ==
@@ -38,7 +38,7 @@ Ko-fi Members is a WordPress plugin that integrates with Ko-fi to manage WordPre
 = How do I set up the Ko-fi webhook? =
 1. Log in to your Ko-fi account.
 2. Go to **Settings > Webhooks**.
-3. Add your WordPress site's webhook URL (e.g., `https://your-site.com/wp-json/kofi-members/v1/webhook`).
+3. Add your WordPress site's webhook URL (e.g., `https://your-site.com/wp-json/members-for-kofi/v1/webhook`).
 
 = Does this plugin delete data on deactivation? =
 No, the plugin does not delete any data on deactivation. However, you can manually delete data by uninstalling the plugin.

--- a/src/Admin/AdminSettings.php
+++ b/src/Admin/AdminSettings.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,12 +15,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KoFiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Admin;
+namespace MembersForKofi\Admin;
 
-use KofiMembers\Webhook\Webhook;
+use MembersForKofi\Webhook\Webhook;
 
 use function add_settings_section;
 use function add_settings_field;
@@ -29,12 +29,12 @@ use function add_settings_error;
 use function get_editable_roles;
 
 /**
- * Handles the admin settings for the Ko-fi Members plugin.
+ * Handles the admin settings for the Members for Ko-fi plugin.
  *
  * This class is responsible for registering and rendering the settings
  * for the plugin in the WordPress admin dashboard.
  *
- * @package KoFiMembers
+ * @package MembersForKofi
  */
 class AdminSettings {
 
@@ -57,7 +57,7 @@ class AdminSettings {
 	}
 
 	/**
-	 * Registers the settings for the Ko-fi Members plugin.
+	 * Registers the settings for the Members for Ko-fi plugin.
 	 *
 	 * This function sets up the settings sections and fields for the plugin
 	 * in the WordPress admin dashboard.
@@ -74,31 +74,31 @@ class AdminSettings {
 		);
 
 		// General tab.
-		add_settings_section( 'kofi_members_general', __( 'General Settings', 'kofi-members' ), '__return_null', 'kofi-members' );
-		add_settings_field( 'verification_token', __( 'Verification Token', 'kofi-members' ), array( $this, 'render_verification_token_field' ), 'kofi-members', 'kofi_members_general' );
-		add_settings_field( 'only_subscriptions', __( 'Only Accept Subscriptions', 'kofi-members' ), array( $this, 'render_only_subscriptions_field' ), 'kofi-members', 'kofi_members_general' );
-		add_settings_field( 'tier_role_map', __( 'Tier to Role Mapping', 'kofi-members' ), array( $this, 'render_tier_role_map_field' ), 'kofi-members', 'kofi_members_general' );
-		add_settings_field( 'default_role', __( 'Default Role (if no match)', 'kofi-members' ), array( $this, 'render_default_role_field' ), 'kofi-members', 'kofi_members_general' );
-		add_settings_field( 'enable_expiry', __( 'Enable Expiry', 'kofi-members' ), array( $this, 'render_expiry_toggle_field' ), 'kofi-members', 'kofi_members_general' );
-		add_settings_field( 'role_expiry_days', __( 'Role Expiry (days)', 'kofi-members' ), array( $this, 'render_role_expiry_field' ), 'kofi-members', 'kofi_members_general' );
+		add_settings_section( 'kofi_members_general', __( 'General Settings', 'members-for-kofi' ), '__return_null', 'members-for-kofi' );
+		add_settings_field( 'verification_token', __( 'Verification Token', 'members-for-kofi' ), array( $this, 'render_verification_token_field' ), 'members-for-kofi', 'kofi_members_general' );
+		add_settings_field( 'only_subscriptions', __( 'Only Accept Subscriptions', 'members-for-kofi' ), array( $this, 'render_only_subscriptions_field' ), 'members-for-kofi', 'kofi_members_general' );
+		add_settings_field( 'tier_role_map', __( 'Tier to Role Mapping', 'members-for-kofi' ), array( $this, 'render_tier_role_map_field' ), 'members-for-kofi', 'kofi_members_general' );
+		add_settings_field( 'default_role', __( 'Default Role (if no match)', 'members-for-kofi' ), array( $this, 'render_default_role_field' ), 'members-for-kofi', 'kofi_members_general' );
+		add_settings_field( 'enable_expiry', __( 'Enable Expiry', 'members-for-kofi' ), array( $this, 'render_expiry_toggle_field' ), 'members-for-kofi', 'kofi_members_general' );
+		add_settings_field( 'role_expiry_days', __( 'Role Expiry (days)', 'members-for-kofi' ), array( $this, 'render_role_expiry_field' ), 'members-for-kofi', 'kofi_members_general' );
 
 		// Logging tab.
-		add_settings_section( 'kofi_members_logging', __( 'Logging', 'kofi-members' ), '__return_null', 'kofi-members' );
-		add_settings_field( 'log_enabled', __( 'Enable Logging', 'kofi-members' ), array( $this, 'render_logging_field' ), 'kofi-members', 'kofi_members_logging' );
-		add_settings_field( 'log_level', __( 'Log Level', 'kofi-members' ), array( $this, 'render_log_level_field' ), 'kofi-members', 'kofi_members_logging' );
+		add_settings_section( 'kofi_members_logging', __( 'Logging', 'members-for-kofi' ), '__return_null', 'members-for-kofi' );
+		add_settings_field( 'log_enabled', __( 'Enable Logging', 'members-for-kofi' ), array( $this, 'render_logging_field' ), 'members-for-kofi', 'kofi_members_logging' );
+		add_settings_field( 'log_level', __( 'Log Level', 'members-for-kofi' ), array( $this, 'render_log_level_field' ), 'members-for-kofi', 'kofi_members_logging' );
 	}
 
 	/**
-	 * Enqueues the admin JavaScript file for the Ko-fi Members settings page.
+	 * Enqueues the admin JavaScript file for the Members for Ko-fi settings page.
 	 *
 	 * @return void
 	 */
 	public function enqueue_admin_scripts(): void {
 		$screen = get_current_screen();
 
-		if ( isset( $screen->id ) && 'toplevel_page_kofi-members' === $screen->id ) {
+		if ( isset( $screen->id ) && 'toplevel_page_members-for-kofi' === $screen->id ) {
 			wp_enqueue_script(
-				'kofi-members-admin-settings',
+				'members-for-kofi-admin-settings',
 				plugins_url( 'assets/js/admin-settings.js', dirname( __DIR__ ) ),
 				array(),
 				'1.0.0',
@@ -106,22 +106,22 @@ class AdminSettings {
 			);
 
 			wp_localize_script(
-				'kofi-members-admin-settings',
+				'members-for-kofi-admin-settings',
 				'kofiMembers',
 				array(
 					'ajaxurl'          => admin_url( 'admin-ajax.php' ),
 					'paginationNonce'  => wp_create_nonce( 'kofi_members_pagination' ),
 					'clearLogsNonce'   => wp_create_nonce( 'kofi_members_clear_logs' ),
 					'rowsPerPageNonce' => wp_create_nonce( 'kofi_members_update_rows_per_page' ),
-					'clearLogsConfirm' => __( 'Are you sure you want to clear all logs? This action cannot be undone.', 'kofi-members' ),
-					'errorMessage'     => __( 'An error occurred. Please try again.', 'kofi-members' ),
+					'clearLogsConfirm' => __( 'Are you sure you want to clear all logs? This action cannot be undone.', 'members-for-kofi' ),
+					'errorMessage'     => __( 'An error occurred. Please try again.', 'members-for-kofi' ),
 				)
 			);
 		}
 	}
 
 	/**
-	 * Sanitizes the options for the Ko-fi Members plugin.
+	 * Sanitizes the options for the Members for Ko-fi plugin.
 	 *
 	 * This function validates and sanitizes the input options
 	 * provided by the user in the settings page.
@@ -132,11 +132,11 @@ class AdminSettings {
 	public function sanitize_options( array $options ): array {
 		$errors = array();
 		if ( empty( $options['verification_token'] ) ) {
-			$errors[] = __( 'Verification Token is required.', 'kofi-members' );
+			$errors[] = __( 'Verification Token is required.', 'members-for-kofi' );
 		}
 
 		if ( empty( $options['role_expiry_days'] ) || ! is_numeric( $options['role_expiry_days'] ) ) {
-			$errors[] = __( 'Role Expiry Days is required and must be a number.', 'kofi-members' );
+			$errors[] = __( 'Role Expiry Days is required and must be a number.', 'members-for-kofi' );
 		}
 
 		if ( ! empty( $errors ) ) {
@@ -177,7 +177,7 @@ class AdminSettings {
 	 */
 	public function render_verification_token_field(): void {
 		$options     = get_option( 'kofi_members_options' );
-		$webhook_url = home_url( '/kofi-webhook/' );
+		$webhook_url = home_url( '/webhook-kofi/' );
 
 		// Verification Token Input.
 		echo '<input type="text" name="kofi_members_options[verification_token]" value="' . esc_attr( $options['verification_token'] ?? '' ) . '" class="regular-text">';
@@ -185,8 +185,8 @@ class AdminSettings {
 		// Description for Verification Token.
 		$description = sprintf(
 			// translators: %s is a link to the Ko-fi Webhooks Management page.
-			esc_html__( 'This token is used to verify incoming webhook requests from Ko-fi. Paste the verification token from this page: %s and open the Advanced box.', 'kofi-members' ),
-			'<a href="' . esc_url( 'https://ko-fi.com/manage/webhooks?src=sidemenu' ) . '" target="_blank">' . esc_html__( 'Ko-fi Webhooks Management', 'kofi-members' ) . '</a>'
+			esc_html__( 'This token is used to verify incoming webhook requests from Ko-fi. Paste the verification token from this page: %s and open the Advanced box.', 'members-for-kofi' ),
+			'<a href="' . esc_url( 'https://ko-fi.com/manage/webhooks?src=sidemenu' ) . '" target="_blank">' . esc_html__( 'Ko-fi Webhooks Management', 'members-for-kofi' ) . '</a>'
 		);
 		echo '<p class="description">' . wp_kses(
 			$description,
@@ -200,12 +200,12 @@ class AdminSettings {
 
 		// Webhook URL Textbox and Copy Button.
 		echo '<div style="margin-top: 20px;">';
-		echo '<label for="kofi-webhook-url" style="font-weight: bold; display: block; margin-bottom: 5px;">' . esc_html__( 'Webhook URL:', 'kofi-members' ) . '</label>';
+		echo '<label for="webhook-kofi-url" style="font-weight: bold; display: block; margin-bottom: 5px;">' . esc_html__( 'Webhook URL:', 'members-for-kofi' ) . '</label>';
 		echo '<div style="display: flex; align-items: center; width: 500px;">';
-		echo '<input type="text" id="kofi-webhook-url" value="' . esc_url( $webhook_url ) . '" readonly style="flex: 1; margin-right: 10px;" class="regular-text">';
-		echo '<button type="button" id="copy-webhook-url" class="button button-secondary">' . esc_html__( 'Copy to Clipboard', 'kofi-members' ) . '</button>';
+		echo '<input type="text" id="webhook-kofi-url" value="' . esc_url( $webhook_url ) . '" readonly style="flex: 1; margin-right: 10px;" class="regular-text">';
+		echo '<button type="button" id="copy-webhook-url" class="button button-secondary">' . esc_html__( 'Copy to Clipboard', 'members-for-kofi' ) . '</button>';
 		echo '</div>';
-		echo '<p class="description">' . esc_html__( 'Use this URL to configure your Ko-fi webhook.', 'kofi-members' ) . '</p>';
+		echo '<p class="description">' . esc_html__( 'Use this URL to configure your Ko-fi webhook.', 'members-for-kofi' ) . '</p>';
 		echo '</div>';
 	}
 
@@ -221,7 +221,7 @@ class AdminSettings {
 		$options = get_option( 'kofi_members_options', array() );
 		$checked = ! empty( $options['only_subscriptions'] );
 		echo '<label><input type="checkbox" name="kofi_members_options[only_subscriptions]" value="1" ' . checked( $checked, true, false ) . '> Only assign roles to subscribers.</label>';
-		echo '<p class="description">' . esc_html__( 'When enabled, users must be active subscribers to receive a role.', 'kofi-members' ) . '</p>';
+		echo '<p class="description">' . esc_html__( 'When enabled, users must be active subscribers to receive a role.', 'members-for-kofi' ) . '</p>';
 	}
 
 	/**
@@ -239,7 +239,7 @@ class AdminSettings {
 		$disallowed_roles = Webhook::DISALLOWED_ROLES;
 
 		echo '<table id="tier-role-map-table" class="form-table" style="margin-top:0">';
-		echo '<thead><tr><th>' . esc_html__( 'Ko-fi Tier', 'kofi-members' ) . '</th><th>' . esc_html__( 'Role', 'kofi-members' ) . '</th><th></th></tr></thead><tbody>';
+		echo '<thead><tr><th>' . esc_html__( 'Ko-fi Tier', 'members-for-kofi' ) . '</th><th>' . esc_html__( 'Role', 'members-for-kofi' ) . '</th><th></th></tr></thead><tbody>';
 
 		if ( empty( $map ) ) {
 			$map = array( '' => '' );
@@ -280,8 +280,8 @@ class AdminSettings {
 		echo '</tr>';
 		echo '</template>';
 
-		echo '<p><button type="button" class="button" id="add-tier-role-row">' . esc_html__( 'Add Tier Mapping', 'kofi-members' ) . '</button></p>';
-		echo '<p><em>' . esc_html__( 'Map Ko-fi tiers to WordPress roles. Only exact tier names will be matched.', 'kofi-members' ) . '</em></p>';
+		echo '<p><button type="button" class="button" id="add-tier-role-row">' . esc_html__( 'Add Tier Mapping', 'members-for-kofi' ) . '</button></p>';
+		echo '<p><em>' . esc_html__( 'Map Ko-fi tiers to WordPress roles. Only exact tier names will be matched.', 'members-for-kofi' ) . '</em></p>';
 	}
 
 	/**
@@ -298,12 +298,12 @@ class AdminSettings {
 		$selected = $options['default_role'] ?? array();
 
 		echo '<select name="kofi_members_options[default_role]">';
-		echo '<option value="">' . esc_html__( '— No default —', 'kofi-members' ) . '</option>';
+		echo '<option value="">' . esc_html__( '— No default —', 'members-for-kofi' ) . '</option>';
 		foreach ( $roles as $role_key => $role_details ) {
 			echo '<option value="' . esc_attr( $role_key ) . '"' . selected( $role_key, $selected, false ) . '>' . esc_html( $role_details['name'] ) . '</option>';
 		}
 		echo '</select>';
-		echo '<p class="description">' . esc_html__( 'If no tier matches, or if you are not using tiers, this role will be assigned to the user.', 'kofi-members' ) . '</p>';
+		echo '<p class="description">' . esc_html__( 'If no tier matches, or if you are not using tiers, this role will be assigned to the user.', 'members-for-kofi' ) . '</p>';
 	}
 
 	/**
@@ -347,8 +347,8 @@ class AdminSettings {
 	 */
 	public function render_logging_field(): void {
 		$options = get_option( 'kofi_members_options' );
-		echo '<input type="checkbox" name="kofi_members_options[log_enabled]" value="1"' . checked( 1, $options['log_enabled'] ?? 0, false ) . '> ' . esc_html__( 'Enable logging to file', 'kofi-members' );
-		echo '<p class="description">' . esc_html__( 'Logs plugin activity to a file for debugging and auditing.', 'kofi-members' ) . '</p>';
+		echo '<input type="checkbox" name="kofi_members_options[log_enabled]" value="1"' . checked( 1, $options['log_enabled'] ?? 0, false ) . '> ' . esc_html__( 'Enable logging to file', 'members-for-kofi' );
+		echo '<p class="description">' . esc_html__( 'Logs plugin activity to a file for debugging and auditing.', 'members-for-kofi' ) . '</p>';
 	}
 
 	/**
@@ -401,12 +401,12 @@ class AdminSettings {
 		$this->render_log_level_select(
 			'log_level',
 			$current,
-			esc_html__( 'Minimum severity of log messages to record.', 'kofi-members' )
+			esc_html__( 'Minimum severity of log messages to record.', 'members-for-kofi' )
 		);
 	}
 
 	/**
-	 * Renders the settings page for the Ko-fi Members plugin.
+	 * Renders the settings page for the Members for Ko-fi plugin.
 	 * This function outputs the HTML for the settings page in the WordPress admin dashboard,
 	 * allowing users to configure the plugin's settings.
 	 *
@@ -424,16 +424,16 @@ class AdminSettings {
 
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Ko-fi Members Settings', 'kofi-members' ); ?></h1>
+			<h1><?php esc_html_e( 'Members for Ko-fi Settings', 'members-for-kofi' ); ?></h1>
 			<h2 class="nav-tab-wrapper">
-				<a href="?page=kofi-members&tab=general" class="nav-tab <?php echo 'general' === $active_tab ? 'nav-tab-active' : ''; ?>">
-					<?php esc_html_e( 'General', 'kofi-members' ); ?>
+				<a href="?page=members-for-kofi&tab=general" class="nav-tab <?php echo 'general' === $active_tab ? 'nav-tab-active' : ''; ?>">
+					<?php esc_html_e( 'General', 'members-for-kofi' ); ?>
 				</a>
-				<a href="?page=kofi-members&tab=logging" class="nav-tab <?php echo 'logging' === $active_tab ? 'nav-tab-active' : ''; ?>">
-					<?php esc_html_e( 'Logging', 'kofi-members' ); ?>
+				<a href="?page=members-for-kofi&tab=logging" class="nav-tab <?php echo 'logging' === $active_tab ? 'nav-tab-active' : ''; ?>">
+					<?php esc_html_e( 'Logging', 'members-for-kofi' ); ?>
 				</a>
-				<a href="?page=kofi-members&tab=user_logs" class="nav-tab <?php echo 'user_logs' === $active_tab ? 'nav-tab-active' : ''; ?>">
-					<?php esc_html_e( 'User Logs', 'kofi-members' ); ?>
+				<a href="?page=members-for-kofi&tab=user_logs" class="nav-tab <?php echo 'user_logs' === $active_tab ? 'nav-tab-active' : ''; ?>">
+					<?php esc_html_e( 'User Logs', 'members-for-kofi' ); ?>
 				</a>
 			</h2>
 
@@ -442,22 +442,22 @@ class AdminSettings {
 					<?php settings_fields( 'kofi_members_options' ); ?>
 				<?php endif; ?>
 
-				<div id="kofi-members-tab-general" class="kofi-members-tab" style="<?php echo 'general' === $active_tab ? '' : 'display:none;'; ?>">
-					<h2><?php esc_html_e( 'General Settings', 'kofi-members' ); ?></h2>
+				<div id="members-for-kofi-tab-general" class="members-for-kofi-tab" style="<?php echo 'general' === $active_tab ? '' : 'display:none;'; ?>">
+					<h2><?php esc_html_e( 'General Settings', 'members-for-kofi' ); ?></h2>
 					<table class="form-table">
-						<?php do_settings_fields( 'kofi-members', 'kofi_members_general' ); ?>
+						<?php do_settings_fields( 'members-for-kofi', 'kofi_members_general' ); ?>
 					</table>
 				</div>
 
-				<div id="kofi-members-tab-logging" class="kofi-members-tab" style="<?php echo 'logging' === $active_tab ? '' : 'display:none;'; ?>">
-					<h2><?php esc_html_e( 'Logging Settings', 'kofi-members' ); ?></h2>
+				<div id="members-for-kofi-tab-logging" class="members-for-kofi-tab" style="<?php echo 'logging' === $active_tab ? '' : 'display:none;'; ?>">
+					<h2><?php esc_html_e( 'Logging Settings', 'members-for-kofi' ); ?></h2>
 					<table class="form-table">
-						<?php do_settings_fields( 'kofi-members', 'kofi_members_logging' ); ?>
+						<?php do_settings_fields( 'members-for-kofi', 'kofi_members_logging' ); ?>
 					</table>
 				</div>
 
-				<div id="kofi-members-tab-user_logs" class="kofi-members-tab" style="<?php echo 'user_logs' === $active_tab ? '' : 'display:none;'; ?>">
-					<h2><?php esc_html_e( 'User Logs', 'kofi-members' ); ?></h2>
+				<div id="members-for-kofi-tab-user_logs" class="members-for-kofi-tab" style="<?php echo 'user_logs' === $active_tab ? '' : 'display:none;'; ?>">
+					<h2><?php esc_html_e( 'User Logs', 'members-for-kofi' ); ?></h2>
 					<?php $this->render_user_logs_tab(); ?>
 				</div>
 
@@ -514,14 +514,14 @@ class AdminSettings {
 
 		// Verify the current user has permission to view logs.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( __( 'You do not have permission to access this resource.', 'kofi-members' ) );
+			wp_send_json_error( __( 'You do not have permission to access this resource.', 'members-for-kofi' ) );
 		}
 
 		$paged = isset( $_POST['paged'] ) ? absint( $_POST['paged'] ) : 1;
 
 		// Ensure the paged parameter is valid.
 		if ( $paged < 1 ) {
-			wp_send_json_error( __( 'Invalid page number.', 'kofi-members' ) );
+			wp_send_json_error( __( 'Invalid page number.', 'members-for-kofi' ) );
 		}
 
 		// Render only the logs table for the requested page.
@@ -556,7 +556,7 @@ class AdminSettings {
 
 			wp_send_json_success( $content );
 		} else {
-			wp_send_json_error( __( 'Logs table does not exist.', 'kofi-members' ) );
+			wp_send_json_error( __( 'Logs table does not exist.', 'members-for-kofi' ) );
 		}
 	}
 
@@ -617,17 +617,17 @@ class AdminSettings {
 		<table class="widefat fixed striped">
 			<thead>
 				<tr>
-					<th><?php esc_html_e( 'Timestamp', 'kofi-members' ); ?></th>
-					<th><?php esc_html_e( 'User ID', 'kofi-members' ); ?></th>
-					<th><?php esc_html_e( 'Email', 'kofi-members' ); ?></th>
-					<th><?php esc_html_e( 'Action', 'kofi-members' ); ?></th>
-					<th><?php esc_html_e( 'Role', 'kofi-members' ); ?></th>
+					<th><?php esc_html_e( 'Timestamp', 'members-for-kofi' ); ?></th>
+					<th><?php esc_html_e( 'User ID', 'members-for-kofi' ); ?></th>
+					<th><?php esc_html_e( 'Email', 'members-for-kofi' ); ?></th>
+					<th><?php esc_html_e( 'Action', 'members-for-kofi' ); ?></th>
+					<th><?php esc_html_e( 'Role', 'members-for-kofi' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>
 				<?php if ( empty( $logs ) ) : ?>
 					<tr>
-						<td colspan="5"><?php esc_html_e( 'No logs available.', 'kofi-members' ); ?></td>
+						<td colspan="5"><?php esc_html_e( 'No logs available.', 'members-for-kofi' ); ?></td>
 					</tr>
 				<?php else : ?>
 					<?php foreach ( $logs as $log ) : ?>
@@ -645,18 +645,18 @@ class AdminSettings {
 
 		<div style="display: flex; align-items: center; justify-content: space-between; margin-top: 15px;">
 			<!-- Clear Logs Button -->
-			<form method="post" action="<?php echo esc_url( add_query_arg( 'tab', 'user_logs', admin_url( 'admin.php?page=kofi-members' ) ) ); ?>" style="margin-right: 15px;">
+			<form method="post" action="<?php echo esc_url( add_query_arg( 'tab', 'user_logs', admin_url( 'admin.php?page=members-for-kofi' ) ) ); ?>" style="margin-right: 15px;">
 				<?php wp_nonce_field( 'clear_user_logs_action', 'clear_user_logs_nonce' ); ?>
 				<button type="button" name="clear_logs" class="button button-secondary">
-					<?php esc_html_e( 'Clear Logs', 'kofi-members' ); ?>
+					<?php esc_html_e( 'Clear Logs', 'members-for-kofi' ); ?>
 				</button>
 			</form>
 
 			<!-- Rows Per Page Dropdown -->
 			<form method="get" style="margin-right: 15px;">
-				<input type="hidden" name="page" value="kofi-members">
+				<input type="hidden" name="page" value="members-for-kofi">
 				<input type="hidden" name="tab" value="user_logs">
-				<label for="rows_per_page" style="margin-right: 10px;"><?php esc_html_e( 'Rows per page:', 'kofi-members' ); ?></label>
+				<label for="rows_per_page" style="margin-right: 10px;"><?php esc_html_e( 'Rows per page:', 'members-for-kofi' ); ?></label>
 				<select name="rows_per_page" id="rows_per_page" style="width: auto;">
 					<?php foreach ( array( 10, 25, 50, 100 ) as $option ) : ?>
 						<option value="<?php echo esc_attr( $option ); ?>" <?php selected( $rows_per_page, $option ); ?>>
@@ -674,15 +674,15 @@ class AdminSettings {
 								'base'      => add_query_arg(
 									array(
 										'paged' => '%#%',
-										'page'  => 'kofi-members',
+										'page'  => 'members-for-kofi',
 										'tab'   => 'user_logs',
 									)
 								),
 								'format'    => '',
 								'current'   => $current_page,
 								'total'     => $total_pages,
-								'prev_text' => __( '&laquo; Previous', 'kofi-members' ),
-								'next_text' => __( 'Next &raquo;', 'kofi-members' ),
+								'prev_text' => __( '&laquo; Previous', 'members-for-kofi' ),
+								'next_text' => __( 'Next &raquo;', 'members-for-kofi' ),
 							)
 						)
 					);

--- a/src/Cron/RoleExpiryChecker.php
+++ b/src/Cron/RoleExpiryChecker.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,19 +15,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Cron;
+namespace MembersForKofi\Cron;
 
-use KofiMembers\Logging\UserLogger;
+use MembersForKofi\Logging\UserLogger;
 
 /**
  * Class RoleExpiryChecker
  *
- * Handles the scheduling and execution of role expiry checks for Ko-fi Members.
+ * Handles the scheduling and execution of role expiry checks for Members for Ko-fi.
  *
- * @package KofiMembers\Cron
+ * @package MembersForKofi\Cron
  */
 class RoleExpiryChecker {
 	/**

--- a/src/Logging/LoggerFactory.php
+++ b/src/Logging/LoggerFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,10 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Logging;
+namespace MembersForKofi\Logging;
 
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
@@ -30,7 +30,7 @@ use Monolog\Formatter\LineFormatter;
  * This class provides methods to create a logger with specific settings,
  * reset the logger instance, and retrieve the logger instance.
  *
- * @package KofiMembers\Logging
+ * @package MembersForKofi\Logging
  */
 class LoggerFactory {
 
@@ -76,7 +76,7 @@ class LoggerFactory {
 	 * @return Logger The configured logger instance.
 	 */
 	public static function create_logger( array $settings ): Logger {
-		$logger = new Logger( 'kofi-members' );
+		$logger = new Logger( 'members-for-kofi' );
 
 		$log_level = Logger::toMonologLevel( $settings['log_level'] ?? 'info' );
 
@@ -96,7 +96,7 @@ class LoggerFactory {
 				$wp_filesystem->mkdir( $log_dir, FS_CHMOD_DIR );
 			}
 
-			$log_path       = $log_dir . '/kofi-members.log';
+			$log_path       = $log_dir . '/members-for-kofi.log';
 			$stream_handler = new StreamHandler( $log_path, $log_level );
 			$line_format    = "[%datetime%] %level_name%: %message%\n%context%\n";
 			$formatter      = new LineFormatter( $line_format, 'Y-m-d H:i:s', true, true );

--- a/src/Logging/UserLogger.php
+++ b/src/Logging/UserLogger.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,10 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Logging;
+namespace MembersForKofi\Logging;
 
 use wpdb;
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
  * PHP version 7.4+
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -18,31 +18,31 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
  * @category WordPress_Plugin
- * @package  KofiMembers
+ * @package  MembersForKofi
  * @author   Sune Trudslev <sune@trudslev.net>
  * @license  https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
- * @link     https://github.com/trudslev/kofi-members
+ * @link     https://github.com/trudslev/members-for-kofi
  */
 
-namespace KofiMembers;
+namespace MembersForKofi;
 
-use KofiMembers\Admin\AdminSettings;
-use KofiMembers\Logging\LoggerFactory;
-use KofiMembers\Cron\RoleExpiryChecker;
-use KofiMembers\Webhook\Webhook;
-use KofiMembers\Logging\UserLogger;
+use MembersForKofi\Admin\AdminSettings;
+use MembersForKofi\Logging\LoggerFactory;
+use MembersForKofi\Cron\RoleExpiryChecker;
+use MembersForKofi\Webhook\Webhook;
+use MembersForKofi\Logging\UserLogger;
 
 /**
- * Main plugin class for Ko-fi Members.
+ * Main plugin class for Members for Ko-fi.
  *
  * Handles initialization, activation, deactivation, and uninstall routines,
  * as well as admin menu, settings, logger, cron, and webhook integration.
  *
  * @category WordPress_Plugin
- * @package  KofiMembers
+ * @package  MembersForKofi
  * @author   Sune Trudslev <sune@trudslev.net>
  * @license  https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
- * @link     https://github.com/trudslev/kofi-members
+ * @link     https://github.com/trudslev/members-for-kofi
  */
 class Plugin {
 	/**
@@ -158,16 +158,16 @@ class Plugin {
 	}
 
 	/**
-	 * Adds the Ko-fi Members menu to the WordPress admin dashboard.
+	 * Adds the Members for Ko-fi menu to the WordPress admin dashboard.
 	 *
 	 * Registers the main menu page for the plugin in the admin interface.
 	 */
 	public function add_menu(): void {
 		add_menu_page(
-			__( 'Ko-fi Members', 'kofi-members' ),
-			__( 'Ko-fi Members', 'kofi-members' ),
+			__( 'Members for Ko-fi', 'members-for-kofi' ),
+			__( 'Members for Ko-fi', 'members-for-kofi' ),
 			'manage_options',
-			'kofi-members',
+			'members-for-kofi',
 			array( $this, 'render_settings_page' ),
 			'dashicons-heart',
 			80
@@ -198,7 +198,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function initialize_logger(): void {
-		LoggerFactory::get_logger()->info( 'Ko-fi Members plugin initialized' );
+		LoggerFactory::get_logger()->info( 'Members for Ko-fi plugin initialized' );
 	}
 
 	/**
@@ -229,7 +229,7 @@ class Plugin {
 	 * @return void
 	 */
 	public static function add_rewrite_rules(): void {
-		add_rewrite_rule( '^kofi-webhook/?$', 'index.php?kofi_webhook=1', 'top' );
+		add_rewrite_rule( '^webhook-kofi/?$', 'index.php?kofi_webhook=1', 'top' );
 	}
 
 	/**

--- a/src/Webhook/Webhook.php
+++ b/src/Webhook/Webhook.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,25 +15,25 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Webhook;
+namespace MembersForKofi\Webhook;
 
 use WP_User;
-use KofiMembers\Logging\LoggerFactory;
+use MembersForKofi\Logging\LoggerFactory;
 use Monolog\Logger;
-use KofiMembers\Logging\UserLogger;
+use MembersForKofi\Logging\UserLogger;
 
 use get_option;
 
 /**
- * Handles incoming webhook requests for the Ko-fi Members plugin.
+ * Handles incoming webhook requests for the Members for Ko-fi plugin.
  *
  * This class is responsible for processing webhook payloads, verifying
  * tokens, creating users, and assigning roles based on the received data.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 class Webhook {
 
@@ -53,30 +53,6 @@ class Webhook {
 	 */
 	public function __construct( ?Logger $logger = null ) {
 		$this->logger = $logger ?? LoggerFactory::get_logger();
-	}
-
-	/**
-	 * Registers the webhook endpoint with the WordPress REST API.
-	 *
-	 * This function sets up the REST API route for handling webhook requests.
-	 *
-	 * @return void
-	 */
-	public function register(): void {
-		add_action(
-			'rest_api_init',
-			function () {
-				register_rest_route(
-					'kofi-members/v1',
-					'/webhook',
-					array(
-						'methods'             => 'POST',
-						'callback'            => array( $this, 'handle' ),
-						'permission_callback' => '__return_true',
-					)
-				);
-			}
-		);
 	}
 
 	/**

--- a/tests/Admin/AdminSettingsRenderTest.php
+++ b/tests/Admin/AdminSettingsRenderTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,18 +15,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Tests\Admin;
+namespace MembersForKofi\Tests\Admin;
 
-use KofiMembers\Admin\AdminSettings;
+use MembersForKofi\Admin\AdminSettings;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the AdminSettings class render methods.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 class AdminSettingsRenderTest extends TestCase {
 

--- a/tests/Admin/AdminSettingsTest.php
+++ b/tests/Admin/AdminSettingsTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,13 +15,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Tests\Admin;
+namespace MembersForKofi\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
-use KofiMembers\Admin\AdminSettings;
+use MembersForKofi\Admin\AdminSettings;
 
 /**
  * Unit tests for the AdminSettings class.
@@ -29,7 +29,7 @@ use KofiMembers\Admin\AdminSettings;
  * This class contains tests to verify the functionality of the
  * AdminSettings class, including sanitization and rendering methods.
  *
- * @package KofiMembers\Tests\Admin
+ * @package MembersForKofi\Tests\Admin
  */
 class AdminSettingsTest extends TestCase {
 

--- a/tests/Cron/RoleExpiryCheckerTest.php
+++ b/tests/Cron/RoleExpiryCheckerTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,18 +15,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KoFiMembers
+ * @package MembersForKofi
  */
 
-use KofiMembers\Cron\RoleExpiryChecker;
-use KofiMembers\Logging\UserLogger;
+use MembersForKofi\Cron\RoleExpiryChecker;
+use MembersForKofi\Logging\UserLogger;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Class RoleExpiryCheckerTest
  *
  * Unit tests for the RoleExpiryChecker class, which handles the removal of expired roles
- * assigned to users based on the Ko-fi Members plugin settings.
+ * assigned to users based on the Members for Ko-fi plugin settings.
  */
 class RoleExpiryCheckerTest extends \WP_UnitTestCase {
 

--- a/tests/Logging/LoggerFactoryTest.php
+++ b/tests/Logging/LoggerFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,12 +15,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KoFiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Tests\Logging;
+namespace MembersForKofi\Tests\Logging;
 
-use KofiMembers\Logging\LoggerFactory;
+use MembersForKofi\Logging\LoggerFactory;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;

--- a/tests/Logging/UserLoggerTest.php
+++ b/tests/Logging/UserLoggerTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,19 +15,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KoFiMembers
+ * @package MembersForKofi
  */
 
-namespace KofiMembers\Tests\Logging;
+namespace MembersForKofi\Tests\Logging;
 
-use KofiMembers\Logging\UserLogger;
+use MembersForKofi\Logging\UserLogger;
 
 /**
  * Class UserLoggerTest
  *
  * Unit tests for the UserLogger class.
  *
- * @package KoFiMembers\Tests\Logging
+ * @package MembersForKofi\Tests\Logging
  */
 class UserLoggerTest extends \WP_UnitTestCase {
 	/**
@@ -60,7 +60,7 @@ class UserLoggerTest extends \WP_UnitTestCase {
 	/**
 	 * Tests logging an action.
 	 *
-	 * @covers \KofiMembers\Logging\UserLogger::log_action
+	 * @covers \MembersForKofi\Logging\UserLogger::log_action
 	 */
 	public function test_log_action(): void {
 		global $wpdb;
@@ -84,7 +84,7 @@ class UserLoggerTest extends \WP_UnitTestCase {
 	/**
 	 * Tests logging a role assignment.
 	 *
-	 * @covers \KofiMembers\Logging\UserLogger::log_role_assignment
+	 * @covers \MembersForKofi\Logging\UserLogger::log_role_assignment
 	 */
 	public function test_log_role_assignment(): void {
 		global $wpdb;
@@ -106,7 +106,7 @@ class UserLoggerTest extends \WP_UnitTestCase {
 	/**
 	 * Tests logging a role removal.
 	 *
-	 * @covers \KofiMembers\Logging\UserLogger::log_role_removal
+	 * @covers \MembersForKofi\Logging\UserLogger::log_role_removal
 	 */
 	public function test_log_role_removal(): void {
 		global $wpdb;
@@ -128,7 +128,7 @@ class UserLoggerTest extends \WP_UnitTestCase {
 	/**
 	 * Tests logging a donation.
 	 *
-	 * @covers \KofiMembers\Logging\UserLogger::log_donation
+	 * @covers \MembersForKofi\Logging\UserLogger::log_donation
 	 */
 	public function test_log_donation(): void {
 		global $wpdb;

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -18,15 +18,15 @@
  * @package Ko-fiMembers
  */
 
-namespace KofiMembers\Tests;
+namespace MembersForKofi\Tests;
 
-use KofiMembers\Plugin;
+use MembersForKofi\Plugin;
 use WP_UnitTestCase;
 
 /**
  * Class PluginTest
  *
- * This class contains unit tests for the Ko-fi Members plugin.
+ * This class contains unit tests for the Members for Ko-fi plugin.
  */
 class PluginTest extends WP_UnitTestCase {
 
@@ -72,7 +72,7 @@ class PluginTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the Ko-fi Members admin menu is registered.
+	 * Tests that the Members for Ko-fi admin menu is registered.
 	 */
 	public function test_add_menu_registers_menu_page(): void {
 		global $menu;
@@ -80,13 +80,13 @@ class PluginTest extends WP_UnitTestCase {
 
 		$found = false;
 		foreach ( $menu as $item ) {
-			if ( is_array( $item ) && in_array( 'Ko-fi Members', $item, true ) ) {
+			if ( is_array( $item ) && in_array( 'Members for Ko-fi', $item, true ) ) {
 				$found = true;
 				break;
 			}
 		}
 
-		$this->assertTrue( $found, 'Expected Ko-fi Members admin menu to be registered' );
+		$this->assertTrue( $found, 'Expected Members for Ko-fi admin menu to be registered' );
 	}
 
 	/**

--- a/tests/Webhook/WebHookTest.php
+++ b/tests/Webhook/WebHookTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,18 +15,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KoFiMembers
+ * @package MembersForKofi
  */
 
 use PHPUnit\Framework\TestCase;
-use KofiMembers\Webhook\Webhook;
-use KofiMembers\Logging\UserLogger;
-use KofiMembers\Logging\LoggerFactory;
+use MembersForKofi\Webhook\Webhook;
+use MembersForKofi\Logging\UserLogger;
+use MembersForKofi\Logging\LoggerFactory;
 use Monolog\Logger;
 use Dotenv\Dotenv;
 
 /**
- * Unit tests for the Webhook class in the Ko-fi Members plugin.
+ * Unit tests for the Webhook class in the Members for Ko-fi plugin.
  *
  * This class contains test cases to validate the behavior of the Webhook class,
  * including token validation, payload handling, and role assignment.
@@ -190,7 +190,7 @@ class WebhookTest extends TestCase {
 				}
 			);
 
-		$request = new \WP_REST_Request( 'POST', '/kofi-members/v1/webhook' );
+		$request = new \WP_REST_Request( 'POST', '/members-for-kofi/v1/webhook' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
 			json_encode(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * PHPUnit bootstrap file for Ko-fi Members plugin.
+ * PHPUnit bootstrap file for Members for Ko-fi plugin.
  *
- * This file is part of the Ko-fi Members plugin.
+ * This file is part of the Members for Ko-fi plugin.
  *
- * Ko-fi Members is free software: you can redistribute it and/or modify
+ * Members for Ko-fi is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @package KofiMembers
+ * @package MembersForKofi
  * @subpackage Tests
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL-3.0-or-later
  */
@@ -49,7 +49,7 @@ require_once "{$kofi_members_tests_dir}/includes/functions.php";
  * @return void
  */
 function kofi_members_manually_load_plugin() {
-	require dirname( __DIR__ ) . '/kofi-members.php';
+	require dirname( __DIR__ ) . '/members-for-kofi.php';
 }
 tests_add_filter( 'muplugins_loaded', 'kofi_members_manually_load_plugin' );
 

--- a/tests/setup-tests.sh
+++ b/tests/setup-tests.sh
@@ -9,7 +9,7 @@ DB_PASS="${WORDPRESS_DB_PASSWORD}"
 DB_HOST="${WORDPRESS_DB_HOST}"
 
 TESTS_DIR="/tmp/wordpress-tests-lib"
-PLUGIN_DIR="/var/www/html/wp-content/plugins/kofi-members"
+PLUGIN_DIR="/var/www/html/wp-content/plugins/members-for-kofi"
 
 echo ">>> Cloning WordPress develop repo..."
 rm -rf "$TESTS_DIR"


### PR DESCRIPTION
Based on the comments in the automated mail from WordPress.org, I have changed the naming of the plugin and also included the entire file for the GNU Public License 3.0.